### PR TITLE
A few changes that made mutate_cpp working on Ubuntu 16.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 venv
 *.pyc
+*.db

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ After checking out the sources from this repository, you need to create a
 [virtual environment](https://docs.python.org/3/tutorial/venv.html) and install the required packages:
 
 ```bash
-virtualenv -p python3 venv
-venv/bin/pip install -r requirements
+python3 -m venv venv
+venv/bin/pip install -r requirements.txt
 ```
 
 Next, we need to create a database where mutations and the results are stored:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ After checking out the sources from this repository, you need to create a
 [virtual environment](https://docs.python.org/3/tutorial/venv.html) and install the required packages:
 
 ```bash
-python3 -m venv venv
-venv/bin/pip install -r requirements.txt
+virtualenv -p python3 venv
+venv/bin/pip install -r requirements
 ```
 
 Next, we need to create a database where mutations and the results are stored:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,10 @@ from flask import Flask
 from flask_compress import Compress
 from flask_sqlalchemy import SQLAlchemy
 from flask_humanize import Humanize
+import os.path
+import sys
+
+sys.path.append( os.path.dirname( os.path.abspath( __file__ ) ) )
 
 app = Flask(__name__)
 app.config.from_object('config')

--- a/app/utils/SourceFile.py
+++ b/app/utils/SourceFile.py
@@ -117,14 +117,14 @@ class SourceFile:
         ))
 
         # lines: context before
-        patch_lines += [' ' + x + '\n' for x in context_before]
+        patch_lines += [' ' + x + "\r\n" for x in context_before]
         # line: the old value
-        patch_lines.append('-' + old_line + '\n')
+        patch_lines.append('-' + old_line + "\r\n")
         # line: the new value
         if replacement.new_val is not None:
-            patch_lines.append('+' + new_line + '\n')
+            patch_lines.append('+' + new_line + "\r\n")
         # lines: context after
-        patch_lines += [' ' + x + '\n' for x in context_after]
+        patch_lines += [' ' + x + "\r\n" for x in context_after]
 
         patch_text = ''.join(patch_lines)
         return patch_text

--- a/db_create.py
+++ b/db_create.py
@@ -1,8 +1,8 @@
 # coding=utf-8
 
 from migrate.versioning import api
-from config import SQLALCHEMY_DATABASE_URI
-from config import SQLALCHEMY_MIGRATE_REPO
+from app.config import SQLALCHEMY_DATABASE_URI
+from app.config import SQLALCHEMY_MIGRATE_REPO
 from app import db
 import os.path
 

--- a/db_migrate.py
+++ b/db_migrate.py
@@ -3,8 +3,8 @@
 import imp
 from migrate.versioning import api
 from app import db
-from config import SQLALCHEMY_DATABASE_URI
-from config import SQLALCHEMY_MIGRATE_REPO
+from app.config import SQLALCHEMY_DATABASE_URI
+from app.config import SQLALCHEMY_MIGRATE_REPO
 
 if __name__ == '__main__':
     v = api.db_version(SQLALCHEMY_DATABASE_URI, SQLALCHEMY_MIGRATE_REPO)

--- a/db_upgrade.py
+++ b/db_upgrade.py
@@ -1,8 +1,8 @@
 # coding=utf-8
 
 from migrate.versioning import api
-from config import SQLALCHEMY_DATABASE_URI
-from config import SQLALCHEMY_MIGRATE_REPO
+from app.config import SQLALCHEMY_DATABASE_URI
+from app.config import SQLALCHEMY_MIGRATE_REPO
 
 if __name__ == '__main__':
     api.upgrade(SQLALCHEMY_DATABASE_URI, SQLALCHEMY_MIGRATE_REPO)


### PR DESCRIPTION
Now it's simple to initialize and run mutate_cpp in the repository, just clone and do the job. Patches made to work on Ubuntu 16.04. But patches now use \r\n line endings, this is default behavior for git?!