### PR TITLE
Update MarkupSafe to 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-WTF==0.14.2
 humanize==0.5.1
 itsdangerous==0.24
 Jinja2==2.9.6
-MarkupSafe==1.0
+MarkupSafe==1.1.0
 packaging==16.8
 pbr==3.1.1
 psutil==5.3.1


### PR DESCRIPTION
I tried running this program for a project, however 1.0 of markupsafe wouldn't install due to import errors. 1.1.0 works.