### PR TITLE
Fix bug: failed to detect `*/` after `/*`

### DIFF
--- a/app/utils/SourceFile.py
+++ b/app/utils/SourceFile.py
@@ -69,6 +69,8 @@ class SourceFile:
             # recognize the beginning of a line comment
             if line_stripped.startswith('/*'):
                 in_comment = True
+                if line_stripped.endswith('*/'):
+                    in_comment = False
                 continue
 
             # skip assertions


### PR DESCRIPTION
Originally, if source file contains a line that starts with `/*` and ends with `*/`, `SourceFile.py` would detect the starting part only and set `in_comment` as `True`, subsequently treating all following codes as comments until it meets another `*/` in a new pair of `/*` `*/`.