### PR TITLE
update Werkzeug to  0.15.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ SQLAlchemy==1.1.14
 sqlalchemy-migrate==0.11.0
 sqlparse==0.2.3
 Tempita==0.5.2
-Werkzeug==0.15.3
+Werkzeug==0.15.5
 WTForms==2.1


### PR DESCRIPTION
Currently this setup doesn't work "out from the box" because of the compatibility bug of IPython 6.5 and Python 3.8.
Bumping Werkzeug to the 0.15.5 fixes the problem.
[Github issue](https://github.com/ipython/ipython/issues/12558)
[StackOverflow issue](https://stackoverflow.com/questions/60140174/basic-flask-app-not-running-typeerror-required-field-type-ignores-missing-fr)
