### PR TITLE
Added navigation links between patches

### DIFF
--- a/app/templates/v2_patch.html
+++ b/app/templates/v2_patch.html
@@ -14,6 +14,21 @@
 {% endblock %}
 
 {% block content %}
+
+    <div class="d-flex justify-content-between">
+        {% if previous_patch is not none %}
+            <span><a href="{{ url_for('route_v2_project_project_id_patches_patch_id', project_id=project.id, patch_id=previous_patch.id, filter_patch_state=filter_patch_state, filter_confirmation_state=filter_confirmation_state, filter_run_state=filter_run_state) }}">&laquo; Patch {{ previous_patch.id }}</a></span>
+        {% else %}
+            <span></span>
+        {% endif %}
+
+        {% if next_patch is not none %}
+            <span><a href="{{ url_for('route_v2_project_project_id_patches_patch_id', project_id=project.id, patch_id=next_patch.id, filter_patch_state=filter_patch_state, filter_confirmation_state=filter_confirmation_state, filter_run_state=filter_run_state) }}">Patch {{ next_patch.id }} &raquo;</a></span>
+        {% else %}
+        <span></span>
+        {% endif %}
+    </div>
+
     <h1>Patch {{ patch.id }}</h1>
 
     <h2>Patch</h2>

--- a/app/templates/v2_patches.html
+++ b/app/templates/v2_patches.html
@@ -22,6 +22,7 @@
         <thead>
         <tr>
             <th>patch</th>
+            <th>file</th>
             <th>line</th>
             <th>kind</th>
             <th>state</th>
@@ -32,8 +33,9 @@
         {% for patch in patches.items %}
             <tr>
                 <td>
-                    <a href="{{ url_for('route_v2_project_project_id_patches_patch_id', project_id=project.id, patch_id=patch.id) }}">{{ patch.id }}</a>
+                    <a href="{{ url_for('route_v2_project_project_id_patches_patch_id', project_id=project.id, patch_id=patch.id, filter_patch_state=filter_patch_state, filter_confirmation_state=filter_confirmation_state, filter_run_state=filter_run_state) }}">{{ patch.id }}</a>
                 </td>
+                <td>{{ patch.file.filename|basename }}</td>
                 <td>{{ patch.line }}</td>
                 <td><a href="{{ url_for('route_v2_mutators_mutator_id', mutator_id=patch.kind) }}">{{ patch.kind }}</a></td>
                 <td>
@@ -66,7 +68,7 @@
         <ul class="pagination">
             <li class="page-item{% if not patches.has_prev %} disabled{% endif %}">
                 <a class="page-link"
-                   href="{{ url_for('route_v2_project_project_id_patches', project_id=project.id, page=patches.prev_num, patch_state=request.args.get('patch_state'), confirmation_state=request.args.get('confirmation_state')) }}">
+                   href="{{ url_for('route_v2_project_project_id_patches', project_id=project.id, page=patches.prev_num, patch_state=request.args.get('patch_state'), confirmation_state=request.args.get('confirmation_state'), run_state=request.args.get('run_state')) }}">
                     <span>&laquo;</span>
                 </a>
             </li>
@@ -74,7 +76,7 @@
             {% for page in patches.iter_pages() %}
                 {% if page %}
                 <li class="page-item{% if page == patches.page %} active{% endif %}">
-                    <a class="page-link" href="{{ url_for('route_v2_project_project_id_patches', project_id=project.id, page=page, patch_state=request.args.get('patch_state'), confirmation_state=request.args.get('confirmation_state')) }}">{{ page }}</a>
+                    <a class="page-link" href="{{ url_for('route_v2_project_project_id_patches', project_id=project.id, page=page, patch_state=request.args.get('patch_state'), confirmation_state=request.args.get('confirmation_state'), run_state=request.args.get('run_state')) }}">{{ page }}</a>
                 </li>
                 {% else %}
                     <li class="page-item disabled">
@@ -85,7 +87,7 @@
 
             <li class="page-item{% if not patches.has_next %} disabled{% endif %}">
                 <a class="page-link"
-                   href="{{ url_for('route_v2_project_project_id_patches', project_id=project.id, page=patches.next_num, patch_state=request.args.get('patch_state'), confirmation_state=request.args.get('confirmation_state')) }}">
+                   href="{{ url_for('route_v2_project_project_id_patches', project_id=project.id, page=patches.next_num, patch_state=request.args.get('patch_state'), confirmation_state=request.args.get('confirmation_state'), run_state=request.args.get('run_state')) }}">
                     <span>&raquo;</span>
                 </a>
             </li>

--- a/app/templates/v2_project.html
+++ b/app/templates/v2_project.html
@@ -142,17 +142,17 @@
                         <ul>
                             {% if run_stats.run.count._all_.failure %}
                             <li>
-                                <a class="bg-success text-white" href="">{{ run_stats.run.count._all_.failure }} failure</a>
+                                <a class="bg-success text-white" href="{{ url_for('route_v2_project_project_id_patches', project_id=project.id, patch_state='killed', run_state='failure') }}">{{ run_stats.run.count._all_.failure }} failure</a>
                             </li>
                             {% endif %}
                         {% if run_stats.run.count._all_.nochange %}
                             <li>
-                                <a class="bg-success text-white" href="">{{ run_stats.run.count._all_.nochange }} nochange</a>
+                                <a class="bg-success text-white" href="{{ url_for('route_v2_project_project_id_patches', project_id=project.id, patch_state='killed', run_state='nochange') }}">{{ run_stats.run.count._all_.nochange }} nochange</a>
                             </li>
                         {% endif %}
                         {% if run_stats.run.count._all_.timeout %}
                             <li>
-                                <a class="bg-success text-white" href="">{{ run_stats.run.count._all_.timeout }} timeout</a>
+                                <a class="bg-success text-white" href="{{ url_for('route_v2_project_project_id_patches', project_id=project.id, patch_state='killed', run_state='timeout') }}">{{ run_stats.run.count._all_.timeout }} timeout</a>
                             </li>
                         {% endif %}
                         </ul>


### PR DESCRIPTION
When there are a lot of survived patches, it can be quite cumbersome to review them all, since there is no easy way to navigate from patch to patch. We have to either open them in separate tabs, or go back to the table each time.

Therefore, I added links that allow us to move from a patch to the next one, based on the filters that were present in the patch table. This might not be the best solution for UX, but that is not a domain I'm familiar with and it has allowed me to quickly review my projects.

I also added links for the killed subcategories in the tree view for completeness' sake, but I wasn't able to really test it because I have no projects which would generate timeouts.

Also, I added the filename to the patch table. This addition has nothing to do with this PR, but it is such a small change that it seemed silly to open a separate PR for just that. If you would prefer a separate PR, I'll happily change this.

A screenshot of the navigation links:
![navigation_links](https://user-images.githubusercontent.com/2708365/210256787-590c66a0-0e19-445c-83c9-d2197ccbd2df.png)

The patch table with filenames:
![patch_table_with_filenames](https://user-images.githubusercontent.com/2708365/210256966-4085deb8-72d2-46e6-867b-b3a24eaa0c84.png)
