### PR TITLE
Some small UI tweaks

### DIFF
--- a/app/templates/v2_edit_project.html
+++ b/app/templates/v2_edit_project.html
@@ -1,0 +1,68 @@
+{% extends "v2_base.html" %}
+{% set title='Edit project' %}
+
+{% block breadcrumb %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('route_v2_root') }}">Home</a></li>
+        <li class="breadcrumb-item"><a href="{{ url_for('route_v2_projects') }}">Projects</a></li>
+        <li class="breadcrumb-item active">Edit project</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h1>Edit project</h1>
+
+    <form action="" method="post" name="project">
+        {{ form.hidden_tag() }}
+
+        <div class="form-group">
+            <label for="name">Project name</label>
+            {{ form.name(class_='form-control') }}
+             <p class="form-text text-muted">Name of the project.</p>
+        </div>
+
+        <div class="form-group">
+            <label for="name">Working directory</label>
+            {{ form.workdir(class_='form-control') }}
+             <p class="form-text text-muted">The absolute path of a working directory in which the commands will be executed.</p>
+        </div>
+
+        <div class="form-group">
+            <label for="name">Build command</label>
+            {{ form.build_command(class_='form-control') }}
+             <p class="form-text text-muted">The command to build the project.</p>
+        </div>
+
+        <div class="form-group">
+            <label for="name">Quickcheck command</label>
+            {{ form.quickcheck_command(class_='form-control') }}
+             <p class="form-text text-muted">The command to execute a quick check (optional).</p>
+        </div>
+
+        <div class="form-group">
+            <label for="name">Quickcheck timeout</label>
+            {{ form.quickcheck_timeout(class_='form-control') }}
+             <p class="form-text text-muted">Timeout for the quick check (optional).</p>
+        </div>
+
+        <div class="form-group">
+            <label for="name">Test command</label>
+            {{ form.test_command(class_='form-control') }}
+             <p class="form-text text-muted">The command to execute the test suite.</p>
+        </div>
+
+        <div class="form-group">
+            <label for="name">Test timeout</label>
+            {{ form.test_timeout(class_='form-control') }}
+             <p class="form-text text-muted">Timeout for the test suite (optional).</p>
+        </div>
+
+        <div class="form-group">
+            <label for="name">Clean command</label>
+            {{ form.clean_command(class_='form-control') }}
+             <p class="form-text text-muted">Command to clean after executing the test suite (optional).</p>
+        </div>
+
+        <button type="submit" class="btn btn-primary">Edit project</button>
+    </form>
+{% endblock %}

--- a/app/templates/v2_patch.html
+++ b/app/templates/v2_patch.html
@@ -63,17 +63,10 @@
 
     <form action="" method="post" name="project">
         {{ form.hidden_tag() }}
-
-        {% for x in form.confirmation %}
-            <div class="form-check">
-                <label class="form-check-label">
-                    {{ x }} {{ x.data }}
-                </label>
-            </div>
+        {% for choice, label in form.confirmation.choices %}
+            <button type="submit" class="btn {% if choice == form.confirmation.data %}btn-primary focus active{%else%}btn-outline-secondary{% endif %}" name="confirmation" value="{{ choice }}">{{ label }}</button>
         {% endfor %}
-
-        <button type="submit" class="btn btn-primary">Submit</button>
-    </form>
+    </form>    
 
     <h2>Runs</h2>
     <table class="table table-sm">

--- a/app/templates/v2_project.html
+++ b/app/templates/v2_project.html
@@ -12,6 +12,7 @@
 {% block content %}
     <h1>
         <small class="text-muted">Project</small>
+        <a href="{{ url_for('route_v2_projects_edit', project_id=project.id) }}" class="btn btn-primary btn-sm float-right"><i class="fa fa-edit"></i> Edit</a>
         <br>{{ project.name }}
     </h1>
 

--- a/app/templates/v2_projects.html
+++ b/app/templates/v2_projects.html
@@ -27,6 +27,7 @@
                             last finding {{ project.last_finding|humanize }}
                             {% endif %}
                         </p>
+                        <a href="{{ url_for('route_v2_projects_edit', project_id=project.id) }}" class="btn btn-primary btn-sm float-right"><i class="fa fa-edit"></i> Edit</a>
                     </div>
                 </div>
             </div>

--- a/app/views.py
+++ b/app/views.py
@@ -122,6 +122,47 @@ def route_v2_projects_create():
 
     return render_template('v2_create_project.html', form=form)
 
+@app.route('/projects/edit/<int:project_id>', methods=['GET', 'POST'])
+def route_v2_projects_edit(project_id):
+    form = CreateProjectForm()
+    project = Project.query.get(project_id)
+
+    
+    if project is None:
+        abort(403)
+        return
+
+    if not form.validate_on_submit():
+        # Copy from DB to form
+        form.name.data = project.name
+        form.workdir.data = project.workdir
+        form.build_command.data = project.build_command
+        form.quickcheck_command.data = project.quickcheck_command
+        form.quickcheck_timeout.data = project.quickcheck_timeout
+        form.test_command.data = project.test_command
+        form.test_timeout.data = project.test_timeout
+        form.clean_command.data = project.clean_command
+        for field, error_msg in form.errors.items():
+            flash('Error in field "{field}": {error_msg}'.format(
+                field=field,
+                error_msg=' '.join(error_msg)
+            ), category='error')
+
+        return render_template('v2_edit_project.html', form=form)
+
+    # Copy from form to DB
+    project.name = form.name.data
+    project.workdir = form.workdir.data
+    project.build_command = form.build_command.data
+    project.quickcheck_command = form.quickcheck_command.data
+    project.quickcheck_timeout = form.quickcheck_timeout.data
+    project.test_command = form.test_command.data
+    project.test_timeout = form.test_timeout.data
+    project.clean_command = form.clean_command.data
+    db.session.commit()
+    return redirect(url_for('route_v2_project_project_id', project_id=project.id))
+
+
 
 @app.route('/projects/<int:project_id>')
 def route_v2_project_project_id(project_id):


### PR DESCRIPTION
I was playing around with the tool a bit, and found that I had to delete and re-add a project instead of being able to edit it. To fix this, I've added an edit button to the project overview page, as well as an edit button in the top-right of the page of the project itself.

In the second commit, I've changed the buttons around a bit so they submit on click (as opposed to a separate submit button) -- I find this much easier to use :)

There is a decent bit of duplication between `v2_{edit,create}_project.html`, perhaps it could be extracted to a base-class. Not sure about the filename though