### PR TITLE
Add mutator choice for web and cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,7 @@ we click on [example.cpp](http://127.0.0.1:5000/projects/1/files/1), we see the 
 
 - Next to "example.cpp", click on ["generate patches"](http://127.0.0.1:5000/projects/1/files/1/generate).
 - Leave "first line" and "last line" empty to mutate the whole file.
-- Right now, none of the check boxes are actually implemented, so you can ignore all of them - all mutations will be
-  used by default.
+- Select check boxes of mutations you want to use. If none is selected, all mutations will be used by default.
 - Click on "Generate patches".
 
 Back in the [project overview](http://127.0.0.1:5000/projects/1), you see that 14 patches have been generated. You can
@@ -275,11 +274,19 @@ venv/bin/python3 cli/add_files.py --project "Example project" /tmp/cmake-example
 ```
 
 ### `generate_patches.py`
-This script will generate patches for all files in a project.
+This script will generate patches for files in a project using selected mutators.
 
 Example usage:
 ```bash
 venv/bin/python3 cli/generate_patches.py --project "Example project"
+```
+
+Example usage with files and mutators:
+```bash
+venv/bin/python3 cli/generate_patches.py \
+  --project "Example project" \
+  --files /tmp/cmake-example/src/example.cpp:13:-1 \
+  --mutators logicalOperator,lineDeletion
 ```
 
 ### `queue_control.py`
@@ -289,6 +296,26 @@ Example usage:
 ```bash
 venv/bin/python3 cli/queue_control.py start
 ```
+
+## List of mutators
+
+| Mutator | Description |
+|----------|-------------|
+| lineDeletion | Deletes a whole line |
+| logicalOperator | Replaces logical operators (&&, \|\|, and, or, !, not) |
+| comparisonOperator | Replaces comparison operators (==, !=, <, >, <=, >=) |
+| incDecOperator | Swaps increment and decrement operators (++, --) |
+| assignmentOperator | Replaces assignment operators (=, +=, -=, *=, /=, %=) |
+| booleanAssignmentOperator | Replaces Boolean assignment operators (=, &=, \|=, ^=, <<=, >>=) |
+| arithmeticOperator | Replaces arithmetic operators (+, -, *, /, %) |
+| booleanArithmeticOperator | Replaces Boolean arithmetic operators (&, \|, ^, <<, >>) |
+| booleanLiteral | Swaps the Boolean literals true and false |
+| stdInserter | Changes the position where elements are inserted (front_inserter, back_inserter) |
+| stdRangePredicate | Changes the semantics of an STL range predicate (all_of, any_of, none_of) |
+| stdMinMax | Swaps STL minimum by maximum calls (min, max) |
+| decimalNumberLiteral | Replaces decimal number literals with different values |
+| hexNumberLiteral | Replaces hex number literals with different values |
+| iteratorRange | Changes an iterator range (begin, end) |
 
 ## Help!
 

--- a/app/utils/Mutation.py
+++ b/app/utils/Mutation.py
@@ -339,7 +339,7 @@ class IteratorRangeMutator:
         return self.pattern.mutate(line)
 
 
-def get_mutators():
+def get_mutators(mutator_ids=None):
     mutators = [
         LineDeletionMutator(),
         LogicalOperatorMutator(),
@@ -357,5 +357,8 @@ def get_mutators():
         HexNumberLiteralMutator(),
         IteratorRangeMutator()
     ]
+
+    if mutator_ids:
+        mutators = [mutator for mutator in mutators if mutator.mutator_id in mutator_ids]
 
     return {mutator.mutator_id: mutator for mutator in mutators}

--- a/app/utils/SourceFile.py
+++ b/app/utils/SourceFile.py
@@ -25,8 +25,8 @@ class SourceFile:
         # read the relevant content
         self.content = '\n'.join(self.full_content[self.first_line - 1:self.last_line])  # type: str
 
-    def generate_patches(self):
-        mutators = get_mutators()
+    def generate_patches(self, mutator_ids):
+        mutators = get_mutators(mutator_ids)
 
         for line_number, line_raw in self.__get_lines():
             for mutator_name, mutator in mutators.items():

--- a/app/views.py
+++ b/app/views.py
@@ -351,8 +351,9 @@ def route_v2_project_project_id_files_file_id_generate(project_id, file_id):
         except ValueError:
             last_line = -1
 
+        mutators = [key for key in request.form if key not in ['first_line', 'last_line']]
         s = SourceFile(file, first_line, last_line)
-        s.generate_patches()
+        s.generate_patches(mutators)
         flash('Successfully created patches.', category='message')
         return redirect(url_for('route_v2_project_project_id', project_id=project.id))
 


### PR DESCRIPTION
Add functionality to actually choose mutators from web UI and CLI interface.

Also added support for files-filter to _cli/generate_patches.py_. Now it's just like in web version, where user can choose _line_begin_ and _line_end_. I'm not sure if the format of files-filter in CLI is the best one. I would be happy to change format based on your comments.

In README, I added a table of all supported mutators so that users would not have to read source code for available mutator IDs to pass into _cli/generate_patches.py_.